### PR TITLE
FBP-116. Avoid double-dragging event for boundary event

### DIFF
--- a/bpmn-intellij-plugin/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/render/AreaWithZindex.kt
+++ b/bpmn-intellij-plugin/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/render/AreaWithZindex.kt
@@ -13,6 +13,7 @@ enum class AreaType(val nests: Boolean = false) {
     EDGE,
     SHAPE,
     SELECTS_DRAG_TARGET,
+    SHAPE_ATTACHED_TO_ELEMENT,
     SHAPE_THAT_NESTS(true),
     PARENT_PROCESS_SHAPE(true);
 }

--- a/bpmn-intellij-plugin/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/render/Canvas.kt
+++ b/bpmn-intellij-plugin/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/render/Canvas.kt
@@ -207,7 +207,13 @@ class Canvas(private val settings: CanvasConstants) : JPanel() {
                     current
             ))
 
-            this.selectedElements.addAll(elemsUnderRect(interactionCtx.dragSelectionRect!!.toRect(), excludeAreas = setOf(AreaType.PARENT_PROCESS_SHAPE, AreaType.SHAPE_THAT_NESTS)))
+            this.selectedElements.addAll(
+                    elemsUnderRect(
+                            interactionCtx.dragSelectionRect!!.toRect(),
+                            excludeAreas = setOf(AreaType.PARENT_PROCESS_SHAPE, AreaType.SHAPE_THAT_NESTS, AreaType.SHAPE_ATTACHED_TO_ELEMENT)
+                    )
+            )
+
             repaint()
             return
         }

--- a/bpmn-intellij-plugin/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/render/elements/shapes/AnyShapeNestableIconShape.kt
+++ b/bpmn-intellij-plugin/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/render/elements/shapes/AnyShapeNestableIconShape.kt
@@ -55,4 +55,8 @@ class AnyShapeNestableIconShape(
     override fun shapeAnchors(camera: Camera): MutableSet<Point2D.Float> {
         return mutableSetOf()
     }
+
+    override fun areaType(): AreaType {
+        return AreaType.SHAPE_ATTACHED_TO_ELEMENT
+    }
 }

--- a/bpmn-intellij-plugin/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/render/elements/shapes/IconShape.kt
+++ b/bpmn-intellij-plugin/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/render/elements/shapes/IconShape.kt
@@ -27,7 +27,7 @@ open class IconShape(
                 selectionColor()
         )
 
-        return mapOf(shapeCtx.diagramId to AreaWithZindex(area, AreaType.SHAPE, waypointAnchors(ctx.canvas.camera), shapeAnchors(ctx.canvas.camera), index = zIndex(), bpmnElementId = bpmnElementId))
+        return mapOf(shapeCtx.diagramId to AreaWithZindex(area, areaType(), waypointAnchors(ctx.canvas.camera), shapeAnchors(ctx.canvas.camera), index = zIndex(), bpmnElementId = bpmnElementId))
     }
 
     override fun waypointAnchors(camera: Camera): MutableSet<Point2D.Float> {
@@ -43,5 +43,9 @@ open class IconShape(
                 Point2D.Float(cx, cy - halfHeight),
                 Point2D.Float(cx, cy + halfHeight)
         )
+    }
+
+    protected open fun areaType(): AreaType {
+        return AreaType.SHAPE
     }
 }

--- a/bpmn-intellij-plugin/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/render/elements/shapes/ShapeRenderElement.kt
+++ b/bpmn-intellij-plugin/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/render/elements/shapes/ShapeRenderElement.kt
@@ -23,9 +23,8 @@ import com.valb3r.bpmn.intellij.plugin.render.elements.viewtransform.NullViewTra
 import com.valb3r.bpmn.intellij.plugin.state.CurrentState
 import java.awt.geom.Point2D
 import java.awt.geom.Rectangle2D
-import java.util.*
 
-val WAYPOINT_OCCUPY_EPSILON = 1.0f
+const val WAYPOINT_OCCUPY_EPSILON = 1.0f
 
 abstract class ShapeRenderElement(
         override val elementId: DiagramElementId,
@@ -82,7 +81,7 @@ abstract class ShapeRenderElement(
 
     override fun onDragEnd(dx: Float, dy: Float, droppedOn: BpmnElementId?, allDroppedOnAreas: Map<BpmnElementId, AreaWithZindex>): MutableList<Event> {
         // Avoid double dragging by cascade and then by children
-        val emptySortedMap = mapOf<BpmnElementId, AreaWithZindex>().toSortedMap(Comparator.comparingInt {it.id.length}) // Quirk to create sorted map without comparable key
+        val emptySortedMap = linkedMapOf<BpmnElementId, AreaWithZindex>() // Quirk to create sorted map without comparable key
         val result = doOnDragEndWithoutChildren(dx, dy, null, allDroppedOnAreas)
         val alreadyDraggedLocations = result.filterIsInstance<LocationUpdateWithId>().map { it.diagramElementId }.toMutableSet()
         children.forEach {


### PR DESCRIPTION
Fixes #116 