### PR TITLE
FBP-293. Hacketty fix for MacOS empty cells rendered

### DIFF
--- a/bpmn-intellij-plugin-core/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/core/ui/components/MultiEditJTable.kt
+++ b/bpmn-intellij-plugin-core/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/core/ui/components/MultiEditJTable.kt
@@ -1,6 +1,7 @@
 package com.valb3r.bpmn.intellij.plugin.core.ui.components
 
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.util.SystemInfoRt
 import com.intellij.ui.EditorTextField
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBTextArea
@@ -179,9 +180,11 @@ class JBComboBoxCellEditor(val field: ComboBox<*>): AbstractTableCellEditor() {
 
 class EditorTextFieldCellRenderer(val field: EditorTextField): TableCellRenderer {
 
+    private val macOsLabel: JLabel? = if (SystemInfoRt.isMac) JLabel(field.text) else null
+
     override fun getTableCellRendererComponent(
             table: JTable?, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int): Component {
-        return field
+        return macOsLabel ?: field
     }
 }
 

--- a/bpmn-intellij-plugin-core/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/core/ui/components/MultiEditJTable.kt
+++ b/bpmn-intellij-plugin-core/src/main/kotlin/com/valb3r/bpmn/intellij/plugin/core/ui/components/MultiEditJTable.kt
@@ -184,6 +184,7 @@ class EditorTextFieldCellRenderer(val field: EditorTextField): TableCellRenderer
 
     override fun getTableCellRendererComponent(
             table: JTable?, value: Any?, isSelected: Boolean, hasFocus: Boolean, row: Int, column: Int): Component {
+        // MacOS renders EditorTextField as empty cells when they are not edited, so replacing them with label instead
         return macOsLabel ?: field
     }
 }


### PR DESCRIPTION
Fixes #293 